### PR TITLE
Fix errors -- vscode wacky

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -44,11 +44,15 @@ export function activate(context: ExtensionContext) {
               offsets[change.range.start.line] = 0
             }
 
-            let start = change.range.start.translate(
-              0,
-              offsets[change.range.start.line] -
-                spacer.charsForChange(e.document, change)
-            )
+            let startOffset = offsets[change.range.start.line] - spacer.charsForChange(e.document, change)
+            let start = change.range.start
+            try {
+              start = start.translate(0, startOffset)
+            } catch (error) {
+              // VS Code doesn't like negative numbers passed
+              // to translate (even though it works fine), so
+              // this block prevents debug console errors
+            }
 
             let lineEnd = e.document.lineAt(start.line).range.end
 
@@ -117,12 +121,19 @@ class Spacer {
     if (change.text === '!') {
       return 2
     } else if (change.text === '-') {
-      let textRange = doc.getText(
-        new Range(
-          change.range.start.translate(0, -2),
-          change.range.start.translate(0, -1)
-        )
-      )
+      let start = change.range.start
+      let end = change.range.start
+
+      try {
+        start = start.translate(0, -2)
+        end = end.translate(0, -1)
+      } catch (error) {
+        // VS Code doesn't like negative numbers passed
+        // to translate (even though it works fine), so
+        // this block prevents debug console errors
+      }
+
+      let textRange = doc.getText(new Range(start, end))
       if (textRange === ' ') {
         return 4
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -99,7 +99,10 @@ export function activate(context: ExtensionContext) {
             await commands.executeCommand('extension.vim_left');
           }
           await commands.executeCommand('extension.vim_insert');
-        } catch (error) {}
+        } catch (error) {
+          // We don't care if this fails, because it means the user
+          // does NOT have the VSCodeVim extension installed
+        }
         ranges = []
         tagType = -1
       }


### PR DESCRIPTION
VS Code doesn't like negative numbers getting passed to `translate()` (even though it works fine), so this just adds try/catch around the areas where we need to translate a selection in the negative direction so the debug console isn't getting spammed with errors about things that actually work? 

The extension has relied on this behavior for who knows how long, so this is a band-aid for now. Hopefully vscode fixes translate so that it accepts negatives but also doesn't throw errors. 
