### PR TITLE
Fix cursor placement when vim installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 ### [Unreleased]
 
+- Fixed cursor placement when VsCodeVim is also installed
+
 ### 2.2.0
 
 - Fix npm install issues

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -91,14 +91,9 @@ export function activate(context: ExtensionContext) {
       if (ranges.length > 0) {
         await spacer.replace(editor, tagType, ranges)
         try {
-          await commands.executeCommand('extension.vim_escape');
-          if (tagType === spacer.TAG_UNESCAPED || tagType === spacer.TAG_TWIG_PER || tagType == spacer.TAG_TWIG_HASH) {
-            await commands.executeCommand('extension.vim_right');
-          } else if (tagType === spacer.TAG_COMMENT) {
-            await commands.executeCommand('extension.vim_left');
-            await commands.executeCommand('extension.vim_left');
-          }
-          await commands.executeCommand('extension.vim_insert');
+          await commands.executeCommand('extension.vim_escape')
+          await commands.executeCommand('extension.vim_right')
+          await commands.executeCommand('extension.vim_insert')
         } catch (error) {
           // We don't care if this fails, because it means the user
           // does NOT have the VSCodeVim extension installed


### PR DESCRIPTION
The extension wasn't behaving correctly when VSCodeVim is also installed. 

**Broken behavior `|` illustrates cursor position:**
`{{|  }}` 

**Fixed behavior:**
`{{ | }}`