### PR TITLE
Fix cursor placement for vim and cursor editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
-# Change Log
+# Changelog
 ### [Unreleased]
+
+### 2.3.1
+
+- Attempt to fix tricky race condition with cursor placement when using VSCodeVim extension and Cursor.sh editor
 
 ### 2.3.0
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -89,15 +89,16 @@ export function activate(context: ExtensionContext) {
         })
 
       if (ranges.length > 0) {
-        await spacer.replace(editor, tagType, ranges)
-        try {
-          await commands.executeCommand('extension.vim_escape')
-          await commands.executeCommand('extension.vim_right')
-          await commands.executeCommand('extension.vim_insert')
-        } catch (error) {
-          // We don't care if this fails, because it means the user
-          // does NOT have the VSCodeVim extension installed
-        }
+        await spacer.replace(editor, tagType, ranges)?.then(async () => {
+          try {
+            await commands.executeCommand('extension.vim_escape')
+            await commands.executeCommand('extension.vim_right')
+            await commands.executeCommand('extension.vim_insert')
+          } catch (error) {
+            // We don't care if this fails, because it means the user
+            // does NOT have the VSCodeVim extension installed
+          }
+        })
         ranges = []
         tagType = -1
       }


### PR DESCRIPTION
Hopefully this fixes the problem occurring in #34 -- I'm experiencing the same behavior in the cursor editor, but not vscode itself. I've tested as much as I can locally. Will revert this quickly if it breaks anything.